### PR TITLE
Fixed workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Rust CI
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - main
   pull_request:
-    branches: [ master ]
 
 jobs:
   test:
@@ -12,19 +12,25 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-20.04
+          - ubuntu-22.04
         rust:
           - stable
+          - beta
+          - nightly
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install YAJL
         run: sudo apt-get install -y libyajl-dev
         continue-on-error: true
 
+      - name: Install OpenSSL
+        run: sudo apt-get install -y libssl-dev
+
       - name: Checkout Source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          lfs: "true"
+          lfs: true
           submodules: recursive
 
       - name: Install toolchain
@@ -48,7 +54,7 @@ jobs:
       - name: Test
         run: |
           cargo check
-          ROOT_KEYSTORE=~/root_keystore.p12 cargo test --all
+          ROOT_KEYSTORE="${GITHUB_WORKSPACE}/root_keystore.p12" cargo test --all
 
       - name: Build
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+- Fixed workflow file
+- Fixed char to libc::c_char conversion
+- Increase the column width to 100
+
 # 0.0.1 (2023-09-27)
 
 - Initial release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,8 @@ members = [
     "secapi-sys",
     "secapi",
 ]
+
+[workspace.package]
+edition = "2021"
+license = "Apache-2.0"
+readme = "README.md"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,3 @@
 wrap_comments = true
+comment_width = 100
 format_code_in_doc_comments = true

--- a/secapi-sys/build.rs
+++ b/secapi-sys/build.rs
@@ -1,20 +1,20 @@
 /**
-* Copyright 2023 Comcast Cable Communications Management, LLC
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-* SPDX-License-Identifier: Apache-2.0
-*/
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 use std::process::Command;
 
 fn main() {

--- a/secapi-sys/src/lib.rs
+++ b/secapi-sys/src/lib.rs
@@ -1,20 +1,20 @@
 /**
-* Copyright 2023 Comcast Cable Communications Management, LLC
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-* SPDX-License-Identifier: Apache-2.0
-*/
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 use std::error::Error;
 
 use libc::{c_char, c_void, size_t};
@@ -164,7 +164,8 @@ pub enum SaKdfAlgorithm {
     ///
     /// See RFC 5869 for definition.
     HKDF,
-    /// Concat Key Derivation Function Algorithm--a.k.a. the single step key derivation function (SSKDF).
+    /// Concat Key Derivation Function Algorithm--a.k.a. the single step key derivation function
+    /// (SSKDF).
     ///
     /// See NIST SP 56A for definition.
     CONCAT,
@@ -172,7 +173,8 @@ pub enum SaKdfAlgorithm {
     ///
     /// See ANSI X9.63 for definition.
     ANSI_X963,
-    /// CMAC Key Derivation Function Algorithm--a.k.a. the key based key derivation function (KBKDF).
+    /// CMAC Key Derivation Function Algorithm--a.k.a. the key based key derivation function
+    /// (KBKDF).
     ///
     /// See NIST SP 800-108 for definition.
     CMAC,
@@ -180,7 +182,8 @@ pub enum SaKdfAlgorithm {
     ///
     /// See https://github.com/Netflix/msl/wiki/Pre-shared-Keys-or-Model-Group-Keys-Entity-Authentication for definition.
     NETFLIX,
-    /// Common Root Key Ladder Key Derivation Function Algorithm--derives a key from the common SoC root key.
+    /// Common Root Key Ladder Key Derivation Function Algorithm--derives a key from the common SoC
+    /// root key.
     COMMON_ROOT_KEY_LADDER,
 }
 
@@ -315,11 +318,13 @@ pub enum SaStatus {
     NULL_PARAMETER,
     /// Operation failed due to invalid parameter value for specified algorithm.
     INVALID_PARAMETER,
-    /// Operation failed due to key rights enforcement. One or more preconditions required by the key rights were not met.
+    /// Operation failed due to key rights enforcement. One or more preconditions required by the
+    /// key rights were not met.
     OPERATION_NOT_ALLOWED,
     /// Operation failed due to SVP buffer not being fully contained within secure SVP region.
     INVALID_SVP_BUFFER,
-    /// Operation failed due to the combination of parameters not being supported in the implementation.
+    /// Operation failed due to the combination of parameters not being supported in the
+    /// implementation.
     OPERATION_NOT_SUPPORTED,
     /// Operation failed due to self-test failure.
     SELF_TEST,
@@ -348,32 +353,38 @@ pub enum SaUsageFlags {
     DECRYPT = 4,
     /// Key can be used as a signing key in signing or mac operations.
     SIGN = 5,
-    /// Key can be used for AES cipher operations when an analog video output is in an unprotected state.
+    /// Key can be used for AES cipher operations when an analog video output is in an unprotected
+    /// state.
     ///
     /// Any child key (resulting from key derivation, key exchange or unwrap operation) shall not
     /// have this flag set if the parent key did not have it set.
     ALLOWED_ANALOG_UNPROTECTED = 6,
-    /// Key can be used for AES cipher operations when an analog video output is protected using CGMSA.
+    /// Key can be used for AES cipher operations when an analog video output is protected using
+    /// CGMSA.
     ///
     /// Any child key (resulting from key derivation, key exchange or unwrap operation) shall not
     /// have this flag set if the parent key did not have it set.
     ALLOWED_ANALOG_CGMSA = 7,
-    /// Key can be used for AES cipher operations when a digital video output is in an unprotected state.
+    /// Key can be used for AES cipher operations when a digital video output is in an unprotected
+    /// state.
     ///
     /// Any child key (resulting from key derivation, key exchange or unwrap operation) shall not
     /// have this flag set if the parent key did not have it set.
     ALLOWED_DIGITAL_UNPROTECTED = 8,
-    /// Key can be used for AES cipher operations when a digital video output is protected using HDCP 1.4.
+    /// Key can be used for AES cipher operations when a digital video output is protected using
+    /// HDCP 1.4.
     ///
     /// Any child key (resulting from key derivation, key exchange or unwrap operation) shall not
     /// have this flag set if the parent key did not have it set.
     ALLOWED_DIGITAL_HDCP14 = 9,
-    /// Key can be used for AES cipher operations when a digital video output is protected using HDCP 2.2.
+    /// Key can be used for AES cipher operations when a digital video output is protected using
+    /// HDCP 2.2.
     ///
     /// Any child key (resulting from key derivation, key exchange or unwrap operation) shall not
     /// have this flag set if the parent key did not have it set.
     ALLOWED_DIGITAL_HDCP22 = 10,
-    /// Key can be used for AES cipher operations when a digital video output is protected using DTCP.
+    /// Key can be used for AES cipher operations when a digital video output is protected using
+    /// DTCP.
     ///
     /// Any child key (resulting from key derivation, key exchange or unwrap operation) shall not
     /// have this flag set if the parent key did not have it set.
@@ -404,23 +415,25 @@ pub const MAX_NUM_ALLOWED_TA_IDS: usize = 32;
 #[repr(C)]
 pub struct SaRights {
     /// Key identifier. Not used internally by SecAPI.
-    pub id: [c_char; 64],
+    /// TODO(#2): We treat this as a u8 but in the SecAPI3 code this is a char. Should be changed
+    /// upstream to uint8_t to get correct representation.
+    pub id: [u8; 64],
     /// Usage flags bitfield. Flags are set and tested using the SA_USAGE_BIT* macros.
     pub usage_flags: u64,
-    /// Usage flags bitfield for unwrapped child keys. When usage_flags only has SA_USAGE_FLAG_UNWRAP (bit 2) set of
-    /// bits 0-5, then these child_usage_flags apply to any key unwrapped by this key. Flags are set and tested using the
-    /// SA_USAGE_BIT* macros.
+    /// Usage flags bitfield for unwrapped child keys. When usage_flags only has
+    /// SA_USAGE_FLAG_UNWRAP (bit 2) set of bits 0-5, then these child_usage_flags apply to any
+    /// key unwrapped by this key. Flags are set and tested using the SA_USAGE_BIT* macros.
     pub child_usage_flags: u64,
     /// Start of the key validity period in seconds since Unix epoch.
     pub not_before: u64,
     /// End of the key validity period in seconds since Unix epoch.
     pub not_on_or_after: u64,
-    /// List of TAs that are allowed to wield this key. All entries in the array are compared to the
-    /// calling TA's UUID. If any of them match key is allowed to be used by the TA.
+    /// List of TAs that are allowed to wield this key. All entries in the array are compared to
+    /// the calling TA's UUID. If any of them match key is allowed to be used by the TA.
     ///
     /// There are two special case values:
-    /// +  0x00000000000000000000000000000000 matches no TAs.
-    /// +  0xffffffffffffffffffffffffffffffff matches all TAs.
+    /// + 0x00000000000000000000000000000000 matches no TAs.
+    /// + 0xffffffffffffffffffffffffffffffff matches all TAs.
     pub allowed_tas: [SaUuid; MAX_NUM_ALLOWED_TA_IDS],
 }
 
@@ -541,21 +554,24 @@ pub struct SaImportParamtersTypeJ {
     pub khmac: SaKey,
 }
 
-/// Import parameters for a SoC key container. This structure is used to signal the SecApi compatability version of the
-/// key container and to identify the object_id in the key rights. This structure can be extended in a SoC specific way
-/// with additional fields at the end, however the length field must include the sizeof the extended structure.
+/// Import parameters for a SoC key container. This structure is used to signal the SecApi
+/// compatability version of the key container and to identify the object_id in the key rights. This
+/// structure can be extended in a SoC specific way with additional fields at the end, however the
+/// length field must include the sizeof the extended structure.
 #[derive(Debug)]
 #[repr(C)]
 pub struct SaImportParametersSoc {
     /// The size of this structure. The most significant size byte is in length[0] and the least
     /// significant size byte is in length[1].
     pub length: [u8; 2],
-    /// The SecApi version that the key container is compatible with. Must be either version 2 or version 3.
+    /// The SecApi version that the key container is compatible with. Must be either version 2 or
+    /// version 3.
     pub version: u8,
-    /// The default key rights to use only if the key container does not contain included key rights.
+    /// The default key rights to use only if the key container does not contain included key
+    /// rights.
     pub default_rights: SaRights,
-    /// The object ID of the key. The first 8 bytes of the sa_rights.id field will be set to this value in big endian
-    /// form.
+    /// The object ID of the key. The first 8 bytes of the sa_rights.id field will be set to this
+    /// value in big endian form.
     pub object_id: u64,
 }
 

--- a/secapi/src/crypto.rs
+++ b/secapi/src/crypto.rs
@@ -1,20 +1,20 @@
 /**
-* Copyright 2023 Comcast Cable Communications Management, LLC
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-* SPDX-License-Identifier: Apache-2.0
-*/
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 use libc::size_t;
 use secapi_sys as ffi;
 use std::{ffi::c_void, ptr::null_mut};

--- a/secapi/src/crypto.rs
+++ b/secapi/src/crypto.rs
@@ -66,33 +66,25 @@ impl MacInitParameters {
     fn into_ffi_parameters(self) -> MacInitFfiParameters {
         match self {
             Self::CMac => MacInitFfiParameters::CMac,
-            Self::HMac { digest_algorithm } => {
-                MacInitFfiParameters::HMac(ffi::SaMacParametersHmac {
+            Self::HMac { digest_algorithm } => MacInitFfiParameters::HMac {
+                params: ffi::SaMacParametersHmac {
                     digest_algorithm: digest_algorithm.into(),
-                })
-            }
+                },
+            },
         }
     }
 }
 
 enum MacInitFfiParameters {
     CMac,
-    HMac(ffi::SaMacParametersHmac),
+    HMac { params: ffi::SaMacParametersHmac },
 }
 
 impl FfiParameters for MacInitFfiParameters {
     fn ffi_ptr(&mut self) -> *mut c_void {
         match self {
             Self::CMac => null_mut(),
-            Self::HMac(params) => params as *mut _ as *mut c_void,
-        }
-    }
-}
-
-impl Drop for MacInitFfiParameters {
-    fn drop(&mut self) {
-        match self {
-            Self::CMac | Self::HMac(_) => {}
+            Self::HMac { params, .. } => params as *mut _ as *mut c_void,
         }
     }
 }

--- a/secapi/src/lib.rs
+++ b/secapi/src/lib.rs
@@ -1,20 +1,20 @@
 /**
-* Copyright 2023 Comcast Cable Communications Management, LLC
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-* SPDX-License-Identifier: Apache-2.0
-*/
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 use std::{error::Error, fmt::Display};
 
 use bitflags::bitflags;
@@ -35,11 +35,13 @@ pub enum ErrorStatus {
     NullParameter,
     /// Operation failed due to invalid parameter value for specified algorithm
     InvalidParameter,
-    /// Operation failed due to key rights enforcement. One or more preconditions required by the key rights were not met
+    /// Operation failed due to key rights enforcement. One or more preconditions required by the
+    /// key rights were not met
     OperationNotAllowed,
     /// Operation failed due to SVP buffer not being fully contained within secure SVP region
     InvalidSvpBuffer,
-    /// Operation failed due to the combination of parameters not being supported in the implementation
+    /// Operation failed due to the combination of parameters not being supported in the
+    /// implementation
     OperationNotSupported,
     /// Operation failed due to self-test failure
     SelfTest,
@@ -243,8 +245,8 @@ pub struct Rights {
     not_before: NaiveDateTime,
     /// End of the key validity period
     not_on_or_after: NaiveDateTime,
-    /// List of TAs that are allowed to wield this key. All entries in the array are compared to the
-    /// calling TA's UUID. If any of them match key is allowed to be used by the TA.
+    /// List of TAs that are allowed to wield this key. All entries in the array are compared to
+    /// the calling TA's UUID. If any of them match key is allowed to be used by the TA.
     ///
     /// There are two special case values:
     ///   * 0x00000000000000000000000000000000 matches no TAs.
@@ -266,7 +268,7 @@ impl Rights {
                 | UsageFlags::CACHEABLE,
             child_usage_flags: UsageFlags::empty(),
             not_before: NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
-            /// The max possible date: (December 31, 262143 CE)
+            // The max possible date: (December 31, 262143 CE)
             not_on_or_after: NaiveDate::from_ymd_opt(262143, 12, 31)
                 .unwrap()
                 .and_hms_opt(0, 0, 0)

--- a/secapi/src/lib.rs
+++ b/secapi/src/lib.rs
@@ -35,13 +35,14 @@ pub enum ErrorStatus {
     NullParameter,
     /// Operation failed due to invalid parameter value for specified algorithm
     InvalidParameter,
-    /// Operation failed due to key rights enforcement. One or more preconditions required by the
-    /// key rights were not met
+    /// Operation failed due to key rights enforcement. One or more
+    /// preconditions required by the key rights were not met
     OperationNotAllowed,
-    /// Operation failed due to SVP buffer not being fully contained within secure SVP region
+    /// Operation failed due to SVP buffer not being fully contained within
+    /// secure SVP region
     InvalidSvpBuffer,
-    /// Operation failed due to the combination of parameters not being supported in the
-    /// implementation
+    /// Operation failed due to the combination of parameters not being
+    /// supported in the implementation
     OperationNotSupported,
     /// Operation failed due to self-test failure
     SelfTest,
@@ -74,10 +75,11 @@ impl Display for ErrorStatus {
     }
 }
 
-// Implement the TryFrom for ffi::SaStatus. The tricky part here is that we don't convert
-// directly into ErrorStatus but instead Result<(), ErrorStatus>. The reason for this is that
-// the ffi::SaStatus has the Ok status. Since ErrorStatus only contains errors we can't directly
-// convert between the types because for the SaStatus::OK case we want return Ok(()).
+// Implement the TryFrom for ffi::SaStatus. The tricky part here is that we
+// don't convert directly into ErrorStatus but instead Result<(), ErrorStatus>.
+// The reason for this is that the ffi::SaStatus has the Ok status. Since
+// ErrorStatus only contains errors we can't directly convert between the types
+// because for the SaStatus::OK case we want return Ok(()).
 fn convert_result(sa_status: ffi::SaStatus) -> Result<(), ErrorStatus> {
     match sa_status {
         ffi::SaStatus::OK => Ok(()),
@@ -245,8 +247,9 @@ pub struct Rights {
     not_before: NaiveDateTime,
     /// End of the key validity period
     not_on_or_after: NaiveDateTime,
-    /// List of TAs that are allowed to wield this key. All entries in the array are compared to
-    /// the calling TA's UUID. If any of them match key is allowed to be used by the TA.
+    /// List of TAs that are allowed to wield this key. All entries in the array
+    /// are compared to the calling TA's UUID. If any of them match key is
+    /// allowed to be used by the TA.
     ///
     /// There are two special case values:
     ///   * 0x00000000000000000000000000000000 matches no TAs.
@@ -404,16 +407,7 @@ impl From<DigestAlgorithm> for ffi::SaDigestAlgorithm {
 }
 
 /// Represents parameters passed into FFI functions using a void*
-///
-/// We turn of the drop_bounds warning. Since FFI data structures can hold
-/// raw pointers, the Rust borrow checker will not be able resolve them. FfiParameters
-/// must always implement the Drop trait to force the developer to content with any memory
-/// clean.
-#[allow(drop_bounds)]
-trait FfiParameters
-where
-    Self: Drop,
-{
+trait FfiParameters {
     /// Return the void pointer to the ffi structure the function is expecting
     fn ffi_ptr(&mut self) -> *mut c_void;
 }

--- a/secapi/src/svp.rs
+++ b/secapi/src/svp.rs
@@ -1,20 +1,20 @@
 /**
-* Copyright 2023 Comcast Cable Communications Management, LLC
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-* SPDX-License-Identifier: Apache-2.0
-*/
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 use libc::{c_void, size_t};
 use secapi_sys as ffi;
 
@@ -99,7 +99,7 @@ impl<'a> SvpBuffer<'a> {
         })
     }
 
-    pub fn with_underlying_memory(memory: &'a mut SvpMemory) -> Result<Self, ErrorStatus> {
+    pub fn with_underlying_memory(memory: &'a SvpMemory) -> Result<Self, ErrorStatus> {
         let mut buffer_handle: ffi::SaSvpBuffer = ffi::INVALID_HANDLE;
 
         convert_result(unsafe {
@@ -199,9 +199,10 @@ impl<'a> Drop for SvpBuffer<'a> {
         match underlying_svp_memory.take() {
             Some(svp_memory) => {
                 // TODO(Stefan_Bossbaly@comcast.com): Ugly workaround
-                // Since sa_svp_buffer_release() takes mutable points and we only have a mutable reference
-                // we need to copy the local variables so that we can obtain a mutable reference to them.
-                // SecAPI should be update to accept const pointers so that we do not need to do this workaround.
+                // Since sa_svp_buffer_release() takes mutable points and we only have a mutable
+                // reference we need to copy the local variables so that we can
+                // obtain a mutable reference to them. SecAPI should be update to
+                // accept const pointers so that we do not need to do this workaround.
                 let mut svp_memory_ptr = svp_memory.memory_ptr;
                 let svp_memory_ptr_ptr = &mut svp_memory_ptr as *mut *mut c_void;
                 let mut size = svp_memory.size;


### PR DESCRIPTION
Fix the workflow to build using the Ubuntu 20.04 and 22.04 with the
stable, beta and nightly toolchains for Rust. This ensures that we are
keeping up with Rust changes. Also the wrap_comments and comment_width
parameters in rustfmt need to be run on the nightly toolchain since they
are not considered stable yet.

Also fixed the char conversion. Since one some platforms a char is uint8
and on others it is int8.

PR Checklist:

- [x] Link to related issues: #number
- [x] Add changelog entry linking to issue
- [N/A] Add tests (if needed)
- [N/A] If new feature: added in description / readme
