### PR TITLE
Update to tasecureapi 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Use `.expect()` calls when unwrapping min and max `NaiveDateTime` and
   `NaiveDate`.
 - Switch the return type of `device_id()` from `u64` to `[u8; 8]`
+- Remove use of deprecated NaiveDateTime APIs in favor of DateTime<Utc>
+- Update to tasecureapi 3.4.0
 
 # v0.1.0 (2023-11-22)
 

--- a/secapi-sys/build.rs
+++ b/secapi-sys/build.rs
@@ -81,6 +81,10 @@ fn main() {
     // Note: The order is extremely important here. libsaclient.so must be linked before
     // libstdc++.so and libc.so. The linker will complain about unresolved symbols in libsaclient.so
     // if the two libraries are linked before.
-    println!("cargo:rustc-link-lib=dylib=stdc++");
+    if cfg!(target_os = "macos") {
+        println!("cargo:rustc-link-lib=dylib=c++");
+    } else {
+        println!("cargo:rustc-link-lib=dylib=stdc++");
+    }
     println!("cargo:rustc-link-lib=dylib=c");
 }

--- a/secapi-sys/src/lib.rs
+++ b/secapi-sys/src/lib.rs
@@ -956,15 +956,15 @@ pub struct SaKdfParametersNetflix {
 #[repr(C)]
 pub struct SaKeyExchangeParametersNetflixAuthenticatedDh {
     /// Input wrapping key.
-    in_kw: SaKey,
+    pub in_kw: SaKey,
     /// Derived encryption key.
-    out_ke: *mut SaKey,
+    pub out_ke: *mut SaKey,
     /// Derived encryption key rights.
-    rights_ke: *mut SaRights,
+    pub rights_ke: *mut SaRights,
     /// Derived HMAC key.
-    out_kh: *mut SaKey,
+    pub out_kh: *mut SaKey,
     /// Derived HMAC key rights.
-    rights_kh: *mut SaRights,
+    pub rights_kh: *mut SaRights,
 }
 
 /// Structure to use in sa_svp_buffer_copy_blocks


### PR DESCRIPTION
This update to tasecureapi fixes some compilation issues that were tripping up local builds. Also removed usage of deprecated chrono APIs.

PR Checklist:

- [x] Link to related issues: #number
- [x] Add changelog entry linking to issue
- [x] Add tests (if needed)
- [x] If new feature: added in description / readme
