### PR TITLE
Update package version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# Unreleased
+# Changelog
+
+## Unreleased
+
+## v0.2.0 (2024-08-30)
 
 - Switch `random_bytes` to use const generics
 - Use `.expect()` calls when unwrapping min and max `NaiveDateTime` and
@@ -7,7 +11,7 @@
 - Remove use of deprecated NaiveDateTime APIs in favor of DateTime<Utc>
 - Update to tasecureapi 3.4.0
 
-# v0.1.0 (2023-11-22)
+## v0.1.0 (2023-11-22)
 
 - Initial release
 - Enable the `BUILD_TESTS` cmake variable to disable the compilation of unit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
 ]
 
 [workspace.package]
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"

--- a/secapi-sys/Cargo.toml
+++ b/secapi-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secapi-sys"
-version = "0.1.0"
+version.workspace = true
 authors = [
     "Stefan Bossbaly <Stefan_Bossbaly@comcast.com>",
 ]

--- a/secapi/Cargo.toml
+++ b/secapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secapi"
-version = "0.1.0"
+version.workspace = true
 authors = [
     "Stefan Bossbaly <Stefan_Bossbaly@comcast.com>",
 ]
@@ -21,7 +21,7 @@ system-sa-client = ["secapi-sys/system-sa-client"]
 
 [dependencies]
 libc = "0.2.147"
-secapi-sys = { path = "../secapi-sys" }
+secapi-sys = { path = "../secapi-sys", version = "0.2.0" }
 chrono = "0.4.30"
 bitflags = "2.4.0"
 uuid = "1.4.1"


### PR DESCRIPTION
Updated the changelog and added missing version for secapi-sys in the Cargo manifest.

PR Checklist:

- [x] Link to related issues: #number
- [x] Add changelog entry linking to issue
- [x] Add tests (if needed)
- [x] If new feature: added in description / readme
