### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
Needed to sync git submodules to ensure tasecureapi exists when building.