### PR TITLE
Install libyajl-dev and libssl-dev in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,8 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     steps:
+      - name: Install external dependencies
+        run: sudo apt-get update -y && sudo apt-get -y install libyajl-dev libssl-dev
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Publish needs some external dependencies to build correctly.
