### PR TITLE
Specify license in workspace members

### DIFF
--- a/secapi-sys/Cargo.toml
+++ b/secapi-sys/Cargo.toml
@@ -8,8 +8,9 @@ description = "FFI bindings to SecAPI"
 keywords = ["secure", "storage", "secapi"]
 categories = ["cryptography", "external-ffi-bindings"]
 repository = "https://github.com/rdkcentral/secapi-rust"
-readme = "README.md"
-edition = "2021"
+license.workspace = true
+readme.workspace = true
+edition.workspace = true
 build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/secapi/Cargo.toml
+++ b/secapi/Cargo.toml
@@ -8,8 +8,9 @@ description = "SecAPI bindings"
 keywords = ["crypto", "secure", "secapi"]
 categories = ["cryptography", "api-bindings"]
 repository = "https://github.com/rdkcentral/secapi-rust"
-readme = "README.md"
-edition = "2021"
+license.workspace = true
+readme.workspace = true
+edition.workspace = true
 
 [lib]
 doctest = false


### PR DESCRIPTION
Publishing to crates.io requires the license field to be specified in the cargo manifest.