### PR TITLE
Remove deprecated authors field from Cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Remove the `authors` field from all `Cargo.toml` files
+
 ## v0.3.0 (2025-09-04)
 
 - Use bindgen to automatically generate bindings to `secapi` #22

--- a/secapi-sys/Cargo.toml
+++ b/secapi-sys/Cargo.toml
@@ -1,9 +1,6 @@
 [package]
 name = "secapi-sys"
 version.workspace = true
-authors = [
-    "Stefan Bossbaly <Stefan_Bossbaly@comcast.com>",
-]
 description = "FFI bindings to SecAPI"
 keywords = ["secure", "storage", "secapi"]
 categories = ["cryptography", "external-ffi-bindings"]

--- a/secapi/Cargo.toml
+++ b/secapi/Cargo.toml
@@ -1,9 +1,6 @@
 [package]
 name = "secapi"
 version.workspace = true
-authors = [
-    "Stefan Bossbaly <Stefan_Bossbaly@comcast.com>",
-]
 description = "SecAPI bindings"
 keywords = ["crypto", "secure", "secapi"]
 categories = ["cryptography", "api-bindings"]


### PR DESCRIPTION
This field is deprecated and no longer used for anything so there is no reason to have it in any Cargo.toml files.

See https://github.com/epage/cargo/commit/32d6e9dcfea465a0290321d5559875e1adaa0d49

PR Checklist:

- [ ] Link to related issues: #number
- [ ] Add changelog entry linking to issue
- [ ] Add tests (if needed)
- [ ] If new feature: added in description / readme
